### PR TITLE
Catalog --> Demoserver checks helper

### DIFF
--- a/fabfile.py
+++ b/fabfile.py
@@ -1,9 +1,11 @@
+from collections import defaultdict
 import dns.resolver
 import json
 import os
 import time
 import requests
 import socket
+from urllib.parse import urlparse
 
 from fabric.api import env, task, local, sudo, run, settings
 from fabric.api import get, put, require
@@ -757,3 +759,106 @@ def checkproxies():
     puts(blue('Use the following command to set the PROXY_LIST env var:\n'))
     puts(blue('  export PROXY_LIST="' + PROXY_LIST_value + '"'))
     return proxy_hosts
+
+
+
+# CATALOG DEMO SERVERS
+################################################################################
+
+STUDIO_URL = 'https://studio.learningequality.org'
+API_PUBLIC_ENDPOINT = '/api/public/v1/channels'
+
+CATALOG_URL = "https://catalog.learningequality.org"
+API_CATALOG_ENDPOINT = "/api/catalog?page_size=200&public=true&published=true"
+
+CATALOG_DEMO_SERVERS = {
+    'ar': 'https://kolibri-catalog-ar.learningequality.org',
+    'en': 'https://kolibri-catalog-en.learningequality.org',
+    'es': 'https://kolibri-catalog-es.learningequality.org',
+    'fr': 'https://kolibri-catalog-fr.learningequality.org',
+    'hi': 'https://kolibri-catalog-hi.learningequality.org',
+    'other': 'https://kolibri-demo.learningequality.org',
+}
+
+
+
+
+@task
+def check_catalog_channels():
+    """
+    Obtain the list of public channels on Kolibri Studio and compare with the
+    list of channels imported on the catalog demo servers. Prints the following:
+      - list channels that are not present on any demo servers
+      - list channels that are oudated (studio version > version on demo server)
+      - list channels with missing or broken demo_server_url
+    """
+    # 1. Get Studio channels
+    studio_channels = requests.get(STUDIO_URL + API_PUBLIC_ENDPOINT).json()
+    studio_channels_by_id = dict((ch['id'], ch) for ch in studio_channels)
+    print('Found', len(studio_channels_by_id), 'PUBLIC channels on Studio.')
+
+    # 2. Get Catalog channels
+    catalog_data = requests.get(CATALOG_URL + API_CATALOG_ENDPOINT).json()
+    catalog_channels = catalog_data['results']
+    catalog_channels_by_id = dict((ch['id'], ch) for ch in catalog_channels)
+    print('Found', len(studio_channels_by_id), 'PUBLIC channels in Catalog.')
+
+    # 3. Get Catalog demo server channels
+    demoserver_channels = []
+    for lang, demoserver in CATALOG_DEMO_SERVERS.items():
+        # print('   - getting channel list from the', lang, 'demoserver...')
+        channels = requests.get(demoserver + API_PUBLIC_ENDPOINT).json()
+        for channel in channels:
+            channel['demoserver'] = demoserver
+            channel['lang'] = lang
+            demoserver_channels.append(channel)
+    # group all channels found by `channel_id`
+    demoserver_channels_by_id = defaultdict(list)
+    for ch in demoserver_channels:
+        ch_id = ch['id']
+        demoserver_channels_by_id[ch_id].append(ch)
+    print('Found', len(demoserver_channels_by_id), 'channels on demoservers.')
+
+    # Sanity check: Studio channels and Catalog channels should be identical
+    studio_ids = set(studio_channels_by_id.keys())
+    catalog_ids = set(catalog_channels_by_id.keys())
+    if studio_ids != catalog_ids:
+        print('WARNING: Studio PUBCLIC channels and Catalog channels differ!')
+
+
+    # REPORT A: PUBLIC channels must be imported on at least one demoserver
+    print('\n\nREPORT A: Check no channels missing from catalog demoservers:')
+    for ch_id, studio_ch in studio_channels_by_id.items():
+        if ch_id not in demoserver_channels_by_id:
+            print(' - Cannot find', ch_id, studio_ch['name'])
+
+    # REPORT B: Catalog demoservers must have the latest version of the channel
+    print('\n\nREPORT B: Check channel versions on catalog demoservers:')
+    for ch_id, studio_ch in studio_channels_by_id.items():
+        latest_version = studio_ch["version"]
+        if ch_id in demoserver_channels_by_id:
+            demoserver_channels = demoserver_channels_by_id[ch_id]
+            for channel in demoserver_channels:
+                if channel["version"] < latest_version:
+                    print(' - Channel', ch_id, studio_ch['name'], 'needs to be updated on', channel['demoserver'])
+
+    # REPORT C: Catalog demoservers links must point to an existing channel
+    print('\n\nREPORT C: Check the demo_server_url links in Catalog are good:')
+    for ch_id, catalog_ch in catalog_channels_by_id.items():
+        demo_server_url = catalog_ch["demo_server_url"]
+        if demo_server_url:
+            if ch_id not in demo_server_url:
+                print(' - ERROR: demo_server_url', demo_server_url, 'does not contain', ch_id)
+            parsed_url_obj = urlparse(demo_server_url)
+            catalog_demoserver = parsed_url_obj.scheme + '://' + parsed_url_obj.netloc
+            if ch_id in demoserver_channels_by_id:
+                found = False
+                demoserver_channels = demoserver_channels_by_id[ch_id]
+                for channel in demoserver_channels:
+                    if channel['demoserver'] == catalog_demoserver:
+                        found = True
+                if not found:
+                    print(' - Channel', ch_id, catalog_ch['name'], 'has demo_server_url',
+                        demo_server_url, 'but it is not present on that server')
+        else:
+            print(' - Channel', ch_id, catalog_ch['name'], 'does not have a demo_server_url')


### PR DESCRIPTION
example output

```
fab check_catalog_channels
Found 86 PUBLIC channels on Studio.
Found 86 PUBLIC channels in Catalog.
Found 90 channels on demoservers.


REPORT A: Check no channels missing from catalog demoservers:
 - Cannot find 57341c56cc785c2a9bbbc3a4a7e1a65c World Health Organization COVID Advice for Public
 - Cannot find 8db463b116d24a6c8f56c4df4fa88041 Tackling Violence Film Series
 - Cannot find 9400c5576dd55963b597e1ba0b50de75 World Health Organization COVID Advice for Public


REPORT B: Check channel versions on catalog demoservers:
 - Channel 000409f81dbe5d1ba67101cb9fed4530 Touchable Earth (en) needs to be updated on https://kolibri-demo.learningequality.org
 - Channel 131e543dbecf5776bb13cfcfddf05605 Pratham Books' StoryWeaver needs to be updated on https://kolibri-demo.learningequality.org
 - Channel 197934f144305350b5820c7c4dd8e194 PhET Interactive Simulations (English) needs to be updated on https://kolibri-demo.learningequality.org
 - Channel 362ecc59a30e53539f7b8d7fd6f1fcc5 ELD King Khaled University Learning (العربيّة) needs to be updated on https://kolibri-demo.learningequality.org
 - Channel 3eaf194585ca4051bdfded581e85b072 Stop It at the Start Toolkit needs to be updated on https://kolibri-catalog-ar.learningequality.org
 - Channel 624e09bb5eeb4d20aa8de62e7b4778a0 How to get started with Kolibri needs to be updated on https://kolibri-catalog-ar.learningequality.org
 - Channel 624e09bb5eeb4d20aa8de62e7b4778a0 How to get started with Kolibri needs to be updated on https://kolibri-catalog-en.learningequality.org
 - Channel 624e09bb5eeb4d20aa8de62e7b4778a0 How to get started with Kolibri needs to be updated on https://kolibri-catalog-es.learningequality.org
 - Channel 624e09bb5eeb4d20aa8de62e7b4778a0 How to get started with Kolibri needs to be updated on https://kolibri-catalog-fr.learningequality.org
 - Channel 878ec2e6f88c5c268b1be6f202833cd4 Khan Academy (Français) needs to be updated on https://kolibri-demo.learningequality.org
 - Channel a9b25ac9814742c883ce1b0579448337 TESSA - Teacher Resources needs to be updated on https://kolibri-demo.learningequality.org
 - Channel b431ba9f16a3588b89700f3eb8281af0 Hsoub Academy (العربيّة) needs to be updated on https://kolibri-demo.learningequality.org
 - Channel c8540424d77f44f8ae306e22d3b14eaf All About the Coronavirus needs to be updated on https://kolibri-catalog-en.learningequality.org
 - Channel c984c3f6cec55ecc997769213e5a855d CK-12 Spanish needs to be updated on https://kolibri-catalog-es.learningequality.org
 - Channel e66cd89375845ebf864ea00005be902d ELD Teacher Professional Development Cources (العربيّة) needs to be updated on https://kolibri-demo.learningequality.org


REPORT C: Check the demo_server_url links in Catalog are good:
 - Channel 8b28761bac075deeb66adc6c80ef119c Osmosis.org has demo_server_url https://kolibri-catalog-ar.learningequality.org/ar/learn/#/topics/8b28761bac075deeb66adc6c80ef119c but it is not present on that server
 - Channel 12cee68c112452a1be3f73e730ec2114 Stanford Digital MEdIC Coronavirus Toolkit does not have a demo_server_url
 - Channel 3eaf194585ca4051bdfded581e85b072 Stop It at the Start Toolkit does not have a demo_server_url
 - Channel 8db463b116d24a6c8f56c4df4fa88041 Tackling Violence Film Series does not have a demo_server_url
 - Channel 9400c5576dd55963b597e1ba0b50de75 World Health Organization COVID Advice for Public does not have a demo_server_url
 - Channel f5bdd2a05a895bc6a242ec5359a11dd6 World Health Organization COVID Advice for Public does not have a demo_server_url
 - Channel a1239cf0220a5f8cb633d6d1cafcb9a2 World Health Organization COVID Advice for Public does not have a demo_server_url
 - Channel 90de6b49f71251c1855e34a416da2f20 World Health Organization COVID Advice for Public does not have a demo_server_url
 - Channel 57341c56cc785c2a9bbbc3a4a7e1a65c World Health Organization COVID Advice for Public does not have a demo_server_url
 - Channel 6cb19f6919055fe8991b0d323c5eed28 World Health Organization COVID Advice for Public does not have a demo_server_url

Done.
```